### PR TITLE
Add install instructions for Backlog.md CLI

### DIFF
--- a/instruction.md
+++ b/instruction.md
@@ -1,0 +1,24 @@
+# Installing Backlog.md CLI in the Codex environment
+
+The CLI is distributed via npm and works with both Bun and Node.js.
+
+1. **Install using Bun**
+
+   ```bash
+   bun add -g backlog.md@0.3.3
+   ```
+
+2. **Install using npm**
+
+   ```bash
+   npm install -g backlog.md@0.3.3
+   ```
+
+3. **Verify the installation**
+
+   ```bash
+   backlog --version
+   ```
+   You should see `0.3.3` as the output.
+
+Once installed, you can run `backlog` commands from any repository.


### PR DESCRIPTION
## Summary
- add `instruction.md` with steps for installing Backlog.md CLI v0.3.3

## Related Tasks
- closes task-100.8

## Testing
- `bun test --no-color`
- `bun run check`


------
https://chatgpt.com/codex/tasks/task_e_68630ebfc42483269ef24848bb4ef17f