### PR TITLE
Use backlog directory instead of .backlog

### DIFF
--- a/.backlog/docs/readme.md
+++ b/.backlog/docs/readme.md
@@ -17,4 +17,4 @@ List all documents with `backlog doc list`.
 - `milestones`: Project milestones
 - `date_format`: Format for `created_date` values (default `yyyy-mm-dd`)
 
-Default statuses are `To Do`, `In Progress`, and `Done`. Draft tasks live in `.backlog/drafts`.
+Default statuses are `To Do`, `In Progress`, and `Done`. Draft tasks live in `backlog/drafts`.

--- a/.backlog/tasks/readme.md
+++ b/.backlog/tasks/readme.md
@@ -26,9 +26,9 @@ Define the initial Backlog working directory structure and create the first set 
 
 ## Acceptance Criteria (Optional)
 
-- [x] `.backlog` directory structure created.
+- [x] `backlog` directory structure created.
 - [x] Initial `config.yml` created.
-- [x] Markdown task files for Milestones 1, 2, and 3 high-level tasks created in `.backlog/tasks/` or `.backlog/draft/`.
+- [x] Markdown task files for Milestones 1, 2, and 3 high-level tasks created in `backlog/tasks/` or `backlog/draft/`.
 - [x] All initial tasks committed to the Git repository.
 - [x] `agents.md` file for AI Agent instructions
 

--- a/.cursorrules
+++ b/.cursorrules
@@ -26,14 +26,14 @@
 ## 1. Project Structure and Navigation
 
 1.1 Always check the project structure in `AGENTS.md` before making changes
-1.2 Follow the directory structure under `.backlog/` (see [Project Structure](./AGENTS.md#structure))
+1.2 Follow the directory structure under `backlog/` (see [Project Structure](./AGENTS.md#structure))
 
 - Never modify files outside the designated project directories
 - Always verify file locations before making changes
 
 ```markdown
 backlog.md/ (Root folder for "Backlog.md" project)
-└── .backlog/ ("Backlog.md" folder for managing tasks and docs)
+└── backlog/ ("Backlog.md" folder for managing tasks and docs)
     ├── drafts/ (list of tasks that are not ready to be implemented)
     ├── tasks/ (list of tasks that are ready to be implemented)
     ├── archive/ (tasks that are no longer relevant)
@@ -52,7 +52,7 @@ Each folder contains a `readme.md` file with instructions on how to use the Back
 
 ### 2.1 Source of Truth
 
-- Tasks live under **`.backlog/tasks/`** (drafts under **`.backlog/drafts/`**)
+- Tasks live under **`backlog/tasks/`** (drafts under **`backlog/drafts/`**)
 - Each has YAML frontmatter & markdown content
 - The task **markdown file** defines what to implement
 
@@ -93,7 +93,7 @@ Always ensure you have:
 
 3.1 All documentation must be in Markdown format
 3.2 Update relevant `README.md` files when making changes
-3.3 Document architectural decisions in `.backlog/decisions/`
+3.3 Document architectural decisions in `backlog/decisions/`
 3.4 Maintain clear and concise documentation
 3.5 Include examples in documentation where appropriate
 
@@ -120,7 +120,7 @@ Always ensure you have:
 6.1 Always verify task requirements before implementation
 6.2 Use semantic search to understand existing code
 6.3 Check for similar implementations before creating new features
-6.4 Document any assumptions in PR descriptions and `.backlog/decisions/`
+6.4 Document any assumptions in PR descriptions and `backlog/decisions/`
 6.5 Consider edge cases and error scenarios
 
 ## 7. Configuration Management

--- a/.npmignore
+++ b/.npmignore
@@ -10,7 +10,7 @@ backlog
 
 # Development files
 .github/
-.backlog/
+backlog/
 .claude/
 .git/
 .gitignore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 ```markdown
 backlog.md/ (Root folder for "Backlog.md" project)
-└── .backlog/ ("Backlog.md" folder for managing tasks and docs)
+└── backlog/ ("Backlog.md" folder for managing tasks and docs)
     ├── drafts/ (list of tasks that are not ready to be implemented)
     ├── tasks/ (list of tasks that are ready to be implemented)
     ├── archive/ (tasks that are no longer relevant)
@@ -21,7 +21,7 @@ Each folder contains a `README.md` file with instructions on how to use the Back
 
 ## 1. Source of Truth
 
-- Tasks live under **`.backlog/tasks/`** (drafts under **`.backlog/drafts/`**).
+- Tasks live under **`backlog/tasks/`** (drafts under **`backlog/drafts/`**).
 - Each has YAML frontmatter & markdown content.
 - The task **markdown file** defines what to implement.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ```markdown
 backlog.md/ (Root folder for "Backlog.md" project)
-└── .backlog/ ("Backlog.md" folder for managing tasks and docs)
+└── backlog/ ("Backlog.md" folder for managing tasks and docs)
     ├── drafts/ (list of tasks that are not ready to be implemented)
     ├── tasks/ (list of tasks that are ready to be implemented)
     ├── archive/ (tasks that are no longer relevant)
@@ -44,7 +44,7 @@ This is the **Backlog.md** project - a lightweight git + markdown project manage
 
 - **CLI Tool**: Built with Bun and TypeScript as a global npm package (`@backlog.md`)
 - **Source Code**: Located in `/src` directory with modular TypeScript structure
-- **Task Management**: Uses markdown files in `.backlog/` directory structure
+- **Task Management**: Uses markdown files in `backlog/` directory structure
 - **Workflow**: Git-integrated with task IDs referenced in commits and PRs
 
 ### Key Components
@@ -56,7 +56,7 @@ This is the **Backlog.md** project - a lightweight git + markdown project manage
 ### AI Agent Integration
 
 - Reference task IDs in commit messages and PR titles when implementing features
-- Use `.backlog/tasks/` markdown files to understand implementation requirements
+- Use `backlog/tasks/` markdown files to understand implementation requirements
 - Include a `## Description` section and a `## Acceptance Criteria` checklist in every task file
 - Add an `## Implementation Plan` section before starting work to outline your approach
 - Use `--ac` flag when creating tasks to set acceptance criteria directly

--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ backlog task create "Render markdown as kanban"
 backlog board view
 ```
 
-All data is saved under `.backlog` folder as human‑readable Markdown with the following format `task-<task-id> - <task-title>.md` (e.g. `task-12 - Fix typo.md`).
+All data is saved under `backlog` folder as human‑readable Markdown with the following format `task-<task-id> - <task-title>.md` (e.g. `task-12 - Fix typo.md`).
 
 ---
 
@@ -78,8 +78,8 @@ Full help: `backlog --help`
 Backlog.md merges the following layers (highest → lowest):
 
 1. CLI flags  
-2. `.backlog/config.yml` (per‑project)  
-3. `~/.backlog/user` (per‑user)  
+2. `backlog/config.yml` (per‑project)
+3. `~/backlog/user` (per‑user)
 4. Built‑ins  
 
 Key options:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -109,7 +109,7 @@ program
 
 			// if (reporter) {
 			// 	if (storeGlobal) {
-			// 		const globalPath = join(homedir(), ".backlog", "user");
+			// 		const globalPath = join(homedir(), "backlog", "user");
 			// 		await mkdir(dirname(globalPath), { recursive: true });
 			// 		await Bun.write(globalPath, `default_reporter: "${reporter}"\n`);
 			// 	} else {
@@ -144,7 +144,7 @@ async function generateNextId(core: Core, parent?: string): Promise<string> {
 
 		// Load files from all branches in parallel
 		const branchFilePromises = branches.map(async (branch) => {
-			const files = await core.gitOps.listFilesInTree(branch, ".backlog/tasks");
+			const files = await core.gitOps.listFilesInTree(branch, "backlog/tasks");
 			return files
 				.map((file) => {
 					const match = file.match(/task-([\d.]+)/);

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -3,7 +3,7 @@
  */
 export const DEFAULT_DIRECTORIES = {
 	/** Main backlog directory */
-	BACKLOG: ".backlog",
+	BACKLOG: "backlog",
 	/** Active tasks directory */
 	TASKS: "tasks",
 	/** Draft tasks directory */

--- a/src/core/cross-branch-tasks.ts
+++ b/src/core/cross-branch-tasks.ts
@@ -42,9 +42,9 @@ export async function getLatestTaskStatesForIds(
 
 		// Create all file path combinations we need to check
 		const directoryChecks: Array<{ path: string; type: TaskDirectoryType }> = [
-			{ path: ".backlog/tasks", type: "task" },
-			{ path: ".backlog/drafts", type: "draft" },
-			{ path: ".backlog/archive/tasks", type: "archived" },
+			{ path: "backlog/tasks", type: "task" },
+			{ path: "backlog/drafts", type: "draft" },
+			{ path: "backlog/archive/tasks", type: "archived" },
 		];
 
 		// Flatten all checks into a single array for maximum parallelization

--- a/src/core/remote-tasks.ts
+++ b/src/core/remote-tasks.ts
@@ -53,7 +53,7 @@ export async function loadRemoteTasks(
 
 			try {
 				// List files in the branch
-				const files = await gitOps.listFilesInTree(ref, ".backlog/tasks");
+				const files = await gitOps.listFilesInTree(ref, "backlog/tasks");
 
 				if (files.length === 0) {
 					return [];

--- a/src/file-system/operations.ts
+++ b/src/file-system/operations.ts
@@ -365,7 +365,7 @@ export class FileSystem {
 
 	private async loadUserSettings(global = false): Promise<Record<string, string> | null> {
 		const filePath = global
-			? join(homedir(), ".backlog", DEFAULT_FILES.USER)
+			? join(homedir(), "backlog", DEFAULT_FILES.USER)
 			: join(this.projectRoot, DEFAULT_FILES.USER);
 		try {
 			const content = await Bun.file(filePath).text();
@@ -390,7 +390,7 @@ export class FileSystem {
 
 	private async saveUserSettings(settings: Record<string, string>, global = false): Promise<void> {
 		const filePath = global
-			? join(homedir(), ".backlog", DEFAULT_FILES.USER)
+			? join(homedir(), "backlog", DEFAULT_FILES.USER)
 			: join(this.projectRoot, DEFAULT_FILES.USER);
 		await this.ensureDirectoryExists(dirname(filePath));
 		const lines = Object.entries(settings).map(([k, v]) => `${k}: ${v}`);

--- a/src/git/operations.ts
+++ b/src/git/operations.ts
@@ -80,7 +80,7 @@ export class GitOperations {
 	}
 
 	async stageBacklogDirectory(): Promise<void> {
-		await this.execGit(["add", ".backlog/"]);
+		await this.execGit(["add", "backlog/"]);
 	}
 
 	async commitBacklogChanges(message: string): Promise<void> {

--- a/src/guidelines/agent-guidelines.md
+++ b/src/guidelines/agent-guidelines.md
@@ -2,7 +2,7 @@
 
 ## 1. Source of Truth
 
-- Tasks live under **`.backlog/tasks/`** (drafts under **`.backlog/drafts/`**).
+- Tasks live under **`backlog/tasks/`** (drafts under **`backlog/drafts/`**).
 - Every implementation decision starts with reading the corresponding Markdown task file.
 
 ## 2. Typical Workflow

--- a/src/test/cli-parent-shorthand.test.ts
+++ b/src/test/cli-parent-shorthand.test.ts
@@ -39,7 +39,7 @@ describe("CLI parent shorthand option", () => {
 		expect(createSubtaskShort).toBe(0);
 
 		// Find the created subtask file
-		const tasksDir = join(testDir, ".backlog", "tasks");
+		const tasksDir = join(testDir, "backlog", "tasks");
 		const files = await readdir(tasksDir);
 		const subtaskFiles = files.filter((f) => f.startsWith("task-1.1 - ") && f.endsWith(".md"));
 		expect(subtaskFiles.length).toBe(1);
@@ -60,7 +60,7 @@ describe("CLI parent shorthand option", () => {
 		expect(createSubtaskLong).toBe(0);
 
 		// Find both subtask files
-		const tasksDir = join(testDir, ".backlog", "tasks");
+		const tasksDir = join(testDir, "backlog", "tasks");
 		const files = await readdir(tasksDir);
 		const subtaskFiles1 = files.filter((f) => f.startsWith("task-1.1 - ") && f.endsWith(".md"));
 		const subtaskFiles2 = files.filter((f) => f.startsWith("task-1.2 - ") && f.endsWith(".md"));

--- a/src/test/cli.test.ts
+++ b/src/test/cli.test.ts
@@ -39,7 +39,7 @@ describe("CLI Integration", () => {
 			await core.initializeProject("CLI Test Project");
 
 			// Verify directory structure was created
-			const configExists = await Bun.file(join(TEST_DIR, ".backlog", "config.yml")).exists();
+			const configExists = await Bun.file(join(TEST_DIR, "backlog", "config.yml")).exists();
 			expect(configExists).toBe(true);
 
 			// Verify config content
@@ -64,14 +64,14 @@ describe("CLI Integration", () => {
 
 			// Check all expected directories exist
 			const expectedDirs = [
-				".backlog",
-				".backlog/tasks",
-				".backlog/drafts",
-				".backlog/archive",
-				".backlog/archive/tasks",
-				".backlog/archive/drafts",
-				".backlog/docs",
-				".backlog/decisions",
+				"backlog",
+				"backlog/tasks",
+				"backlog/drafts",
+				"backlog/archive",
+				"backlog/archive/tasks",
+				"backlog/archive/drafts",
+				"backlog/docs",
+				"backlog/decisions",
 			];
 
 			for (const dir of expectedDirs) {
@@ -891,7 +891,7 @@ describe("CLI Integration", () => {
 
 			// Verify task exists in archive
 			const { readdir } = await import("node:fs/promises");
-			const archiveFiles = await readdir(join(TEST_DIR, ".backlog", "archive", "tasks"));
+			const archiveFiles = await readdir(join(TEST_DIR, "backlog", "archive", "tasks"));
 			expect(archiveFiles.some((f) => f.startsWith("task-1"))).toBe(true);
 		});
 
@@ -994,7 +994,7 @@ describe("CLI Integration", () => {
 
 			// Verify draft exists in archive
 			const { readdir } = await import("node:fs/promises");
-			const archiveFiles = await readdir(join(TEST_DIR, ".backlog", "archive", "drafts"));
+			const archiveFiles = await readdir(join(TEST_DIR, "backlog", "archive", "drafts"));
 			expect(archiveFiles.some((f) => f.startsWith("task-4"))).toBe(true);
 		});
 
@@ -1332,7 +1332,7 @@ describe("CLI Integration", () => {
 
 			for (const branch of branches) {
 				const ref = `origin/${branch}`;
-				const files = await core.gitOps.listFilesInTree(ref, ".backlog/tasks");
+				const files = await core.gitOps.listFilesInTree(ref, "backlog/tasks");
 				for (const file of files) {
 					const content = await core.gitOps.showFile(ref, file);
 					const remoteTask = parseTask(content);

--- a/src/test/filesystem.test.ts
+++ b/src/test/filesystem.test.ts
@@ -27,13 +27,13 @@ describe("FileSystem", () => {
 	describe("ensureBacklogStructure", () => {
 		it("should create all required directories", async () => {
 			const expectedDirs = [
-				join(TEST_DIR, ".backlog"),
-				join(TEST_DIR, ".backlog", "tasks"),
-				join(TEST_DIR, ".backlog", "drafts"),
-				join(TEST_DIR, ".backlog", "archive", "tasks"),
-				join(TEST_DIR, ".backlog", "archive", "drafts"),
-				join(TEST_DIR, ".backlog", "docs"),
-				join(TEST_DIR, ".backlog", "decisions"),
+				join(TEST_DIR, "backlog"),
+				join(TEST_DIR, "backlog", "tasks"),
+				join(TEST_DIR, "backlog", "drafts"),
+				join(TEST_DIR, "backlog", "archive", "tasks"),
+				join(TEST_DIR, "backlog", "archive", "drafts"),
+				join(TEST_DIR, "backlog", "docs"),
+				join(TEST_DIR, "backlog", "decisions"),
 			];
 
 			for (const dir of expectedDirs) {
@@ -125,7 +125,7 @@ describe("FileSystem", () => {
 			expect(task).toBeNull();
 
 			// Check that file exists in archive
-			const archiveFiles = await readdir(join(TEST_DIR, ".backlog", "archive", "tasks"));
+			const archiveFiles = await readdir(join(TEST_DIR, "backlog", "archive", "tasks"));
 			expect(archiveFiles.some((f) => f.startsWith("task-1"))).toBe(true);
 		});
 
@@ -187,7 +187,7 @@ describe("FileSystem", () => {
 			const draft = await filesystem.loadDraft("task-draft");
 			expect(draft).toBeNull();
 
-			const files = await readdir(join(TEST_DIR, ".backlog", "archive", "drafts"));
+			const files = await readdir(join(TEST_DIR, "backlog", "archive", "drafts"));
 			expect(files.some((f) => f.startsWith("task-draft"))).toBe(true);
 		});
 	});
@@ -250,10 +250,10 @@ describe("FileSystem", () => {
 
 	describe("directory accessors", () => {
 		it("should provide correct directory paths", () => {
-			expect(filesystem.tasksDir).toBe(join(TEST_DIR, ".backlog", "tasks"));
-			expect(filesystem.archiveTasksDir).toBe(join(TEST_DIR, ".backlog", "archive", "tasks"));
-			expect(filesystem.decisionsDir).toBe(join(TEST_DIR, ".backlog", "decisions"));
-			expect(filesystem.docsDir).toBe(join(TEST_DIR, ".backlog", "docs"));
+			expect(filesystem.tasksDir).toBe(join(TEST_DIR, "backlog", "tasks"));
+			expect(filesystem.archiveTasksDir).toBe(join(TEST_DIR, "backlog", "archive", "tasks"));
+			expect(filesystem.decisionsDir).toBe(join(TEST_DIR, "backlog", "decisions"));
+			expect(filesystem.docsDir).toBe(join(TEST_DIR, "backlog", "docs"));
 		});
 	});
 

--- a/src/test/parallel-loading.test.ts
+++ b/src/test/parallel-loading.test.ts
@@ -22,13 +22,13 @@ class MockGitOps implements Partial<GitOps> {
 
 	async listFilesInTree(ref: string, path: string): Promise<string[]> {
 		if (ref === "origin/main") {
-			return [".backlog/tasks/task-1 - Main Task.md"];
+			return ["backlog/tasks/task-1 - Main Task.md"];
 		}
 		if (ref === "origin/feature") {
-			return [".backlog/tasks/task-2 - Feature Task.md"];
+			return ["backlog/tasks/task-2 - Feature Task.md"];
 		}
 		if (ref === "origin/feature2") {
-			return [".backlog/tasks/task-3 - Feature2 Task.md"];
+			return ["backlog/tasks/task-3 - Feature2 Task.md"];
 		}
 		return [];
 	}

--- a/src/test/start-id.test.ts
+++ b/src/test/start-id.test.ts
@@ -29,7 +29,7 @@ describe("task id generation", () => {
 		const result = Bun.spawnSync(["bun", CLI_PATH, "task", "create", "First"], { cwd: TEST_DIR });
 		expect(result.exitCode).toBe(0);
 
-		const files = await readdir(join(TEST_DIR, ".backlog", "tasks"));
+		const files = await readdir(join(TEST_DIR, "backlog", "tasks"));
 		const first = files.find((f) => f.startsWith("task-1 -"));
 		expect(first).toBeDefined();
 	});


### PR DESCRIPTION
## Summary
- update default directory constant to `backlog`
- adjust CLI and filesystem code for new folder
- update docs and guidelines to use `backlog/`
- update test expectations and `.npmignore`
- run formatter and tests

## Testing
- `bun run check`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_686310bc92488326b442e1503abe9396