### PR TITLE
Add CLI commands for description and notes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -64,6 +64,8 @@ All data is saved under `.backlog` folder as human‑readable Markdown with the 
 | Add plan    | `backlog task edit 7 --plan "Implementation approach"`    |
 | Add AC      | `backlog task edit 7 --ac "New criterion,Another one"`    |
 | Add deps    | `backlog task edit 7 --dep task-1 --dep task-2`     |
+| Set description | `backlog task describe 7 "New details"` |
+| Add notes   | `backlog task notes 7 "Learnings"` |
 | Archive     | `backlog task archive 7`                             |
 | Draft flow  | `backlog draft create "Spike GraphQL"` → `backlog draft promote 3.1` |
 | Demote to draft| `backlog task demote <id>` |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -610,6 +610,40 @@ taskCmd
 	});
 
 taskCmd
+	.command("describe <taskId> <text>")
+	.description("set or replace task description")
+	.action(async (taskId: string, text: string) => {
+		const cwd = process.cwd();
+		const core = new Core(cwd);
+		const task = await core.filesystem.loadTask(taskId);
+		if (!task) {
+			console.error(`Task ${taskId} not found.`);
+			return;
+		}
+		const { updateTaskDescription } = await import("./markdown/serializer.ts");
+		task.description = updateTaskDescription(task.description, text);
+		await core.updateTask(task, true);
+		console.log(`Updated description for ${task.id}`);
+	});
+
+taskCmd
+	.command("notes <taskId> <text>")
+	.description("set implementation notes")
+	.action(async (taskId: string, text: string) => {
+		const cwd = process.cwd();
+		const core = new Core(cwd);
+		const task = await core.filesystem.loadTask(taskId);
+		if (!task) {
+			console.error(`Task ${taskId} not found.`);
+			return;
+		}
+		const { updateTaskImplementationNotes } = await import("./markdown/serializer.ts");
+		task.description = updateTaskImplementationNotes(task.description, text);
+		await core.updateTask(task, true);
+		console.log(`Updated implementation notes for ${task.id}`);
+	});
+
+taskCmd
 	.command("view <taskId>")
 	.description("display task details")
 	.option("--plain", "use plain text output instead of interactive UI")

--- a/src/markdown/serializer.ts
+++ b/src/markdown/serializer.ts
@@ -111,3 +111,34 @@ export function updateTaskImplementationPlan(content: string, plan: string): str
 	// If no Description section found, add at the end
 	return `${content}\n\n${newSection}`;
 }
+
+export function updateTaskDescription(content: string, description: string): string {
+	const descRegex = /## Description\s*\n([\s\S]*?)(?=\n## |$)/i;
+	const newSection = `## Description\n\n${description}`;
+
+	if (descRegex.test(content)) {
+		return content.replace(descRegex, newSection);
+	}
+
+	const firstSection = content.match(/## [^\n]+\n/);
+	if (firstSection && firstSection.index !== undefined) {
+		return `${content.slice(0, firstSection.index)}${newSection}\n\n${content.slice(firstSection.index)}`;
+	}
+
+	return newSection;
+}
+
+export function updateTaskImplementationNotes(content: string, notes: string): string {
+	if (!notes || !notes.trim()) {
+		return content;
+	}
+
+	const notesRegex = /## Implementation Notes\s*\n([\s\S]*?)(?=\n## |$)/i;
+	const newSection = `## Implementation Notes\n\n${notes}`;
+
+	if (notesRegex.test(content)) {
+		return content.replace(notesRegex, newSection);
+	}
+
+	return `${content}\n\n${newSection}`;
+}

--- a/src/test/description-notes.test.ts
+++ b/src/test/description-notes.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { rm } from "node:fs/promises";
+import { join } from "node:path";
+import { Core } from "../core/backlog.ts";
+
+const TEST_DIR = join(process.cwd(), "test-desc-notes");
+const CLI_PATH = join(process.cwd(), "src", "cli.ts");
+
+describe("Description and Notes CLI", () => {
+	beforeEach(async () => {
+		try {
+			await rm(TEST_DIR, { recursive: true, force: true });
+		} catch {
+			// ignore
+		}
+		await Bun.spawn(["mkdir", "-p", TEST_DIR]).exited;
+		await Bun.spawn(["git", "init"], { cwd: TEST_DIR }).exited;
+		await Bun.spawn(["git", "config", "user.name", "Test User"], { cwd: TEST_DIR }).exited;
+		await Bun.spawn(["git", "config", "user.email", "test@example.com"], { cwd: TEST_DIR }).exited;
+
+		const core = new Core(TEST_DIR);
+		await core.initializeProject("Desc Notes Test");
+	});
+
+	afterEach(async () => {
+		try {
+			await rm(TEST_DIR, { recursive: true, force: true });
+		} catch {
+			// ignore
+		}
+	});
+
+	it("should update description using describe command", async () => {
+		const core = new Core(TEST_DIR);
+		await core.createTask(
+			{
+				id: "task-1",
+				title: "Test",
+				status: "To Do",
+				assignee: [],
+				createdDate: "2025-06-19",
+				labels: [],
+				dependencies: [],
+				description: "## Description\n\nInitial",
+			},
+			false,
+		);
+
+		const result = spawnSync("bun", [CLI_PATH, "task", "describe", "1", "Updated description"], {
+			cwd: TEST_DIR,
+			encoding: "utf8",
+		});
+		expect(result.status).toBe(0);
+
+		const task = await core.filesystem.loadTask("task-1");
+		expect(task?.description).toContain("## Description");
+		expect(task?.description).toContain("Updated description");
+	});
+
+	it("should update implementation notes using notes command", async () => {
+		const core = new Core(TEST_DIR);
+		await core.createTask(
+			{
+				id: "task-1",
+				title: "Test",
+				status: "To Do",
+				assignee: [],
+				createdDate: "2025-06-19",
+				labels: [],
+				dependencies: [],
+				description: "## Description\n\nInitial",
+			},
+			false,
+		);
+
+		const result = spawnSync("bun", [CLI_PATH, "task", "notes", "1", "Some notes"], {
+			cwd: TEST_DIR,
+			encoding: "utf8",
+		});
+		expect(result.status).toBe(0);
+
+		const task = await core.filesystem.loadTask("task-1");
+		expect(task?.description).toContain("## Implementation Notes");
+		expect(task?.description).toContain("Some notes");
+	});
+});


### PR DESCRIPTION
## Summary
- implement helper functions to update Description and Implementation Notes sections
- expose new `backlog task describe` and `backlog task notes` commands
- document these commands in README
- add regression tests for description and notes CLI

## Testing
- `npx -y biome format --write src/markdown/serializer.ts src/cli.ts src/test/description-notes.test.ts readme.md`
- `npx -y biome check .`
- `bun test --tap`

------
https://chatgpt.com/codex/tasks/task_e_68630ff2dbc08326bb554ad1fb73dc02